### PR TITLE
Add bot user cleanup command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ testconfig.yml
 testconfig.yaml
 /bin/
 /ecosystem-activity
+/.idea

--- a/cmd/deleteBotRows.go
+++ b/cmd/deleteBotRows.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/chia-network/ecosystem-activity/internal/db"
+	"github.com/chia-network/ecosystem-activity/internal/db/commits"
+	sortedcommits "github.com/chia-network/ecosystem-activity/internal/db/sorted_commits"
+	"github.com/chia-network/ecosystem-activity/internal/db/users"
+	"github.com/chia-network/ecosystem-activity/internal/sorter"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	startDate     string    // The unformatted string given from flag
+	startDateTime time.Time // startDate parsed in to a time object
+)
+
+// deleteBotRowsCmd represents the deleteBotRows command
+var deleteBotRowsCmd = &cobra.Command{
+	Use:   "delete-bots",
+	Short: "Runs the bot deleting script",
+	Long: `New bots may be found that don't get filtered by the bot finding measures currently set.
+
+This uses the bot matching utility functions to discover bots in the prod dataset, and deletes bot related data as it's irrelevant to developer metrics.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Format start date string to time
+		var err error
+		startDateTime, err = time.Parse("2006-01-02", startDate)
+		if err != nil {
+			log.Fatalf("parsed time from flag returned an error: %v", err)
+		}
+
+		// Init db package
+		err = db.Init(viper.GetString("mysql-host"), viper.GetString("mysql-database"), viper.GetString("mysql-user"), viper.GetString("mysql-password"))
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Get all user rows that match listed bot matchers
+		botUsers, err := users.GetBotUserRows()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Log users to be deleted and wait for implicit confirmation
+		logUsers(botUsers)
+		time.Sleep(30 * time.Second)
+
+		for _, u := range botUsers {
+			// Get all commit rows for the user
+			cmts, err := commits.GetAllRowsByUserID(u.ID)
+			if err != nil {
+				log.Error(err)
+				continue
+			}
+
+			// Loop through each commit
+			deletedAll := true // This will be switched to false if a commit is ever skipped
+			for _, cmt := range cmts {
+				// Check if date is after start date, skip if not
+				if cmt.Date.Before(startDateTime) {
+					log.Infof("skipping commit %s for user %s, commit date %s was before start time %s", cmt.SHA, u.Username, cmt.Date.Format("2006-01-02 15:04:05"), startDateTime.Format("2006-01-02 15:04:05"))
+					deletedAll = false
+					continue
+				}
+				log.Infof("deleting commit %s for user %s, commit date %s was after start time %s", cmt.SHA, u.Username, cmt.Date.Format("2006-01-02 15:04:05"), startDateTime.Format("2006-01-02 15:04:05"))
+
+				// Delete the row in sorted_commits table
+				err = sortedcommits.DeleteRow(cmt.ID)
+				if err != nil {
+					log.Error(err)
+					deletedAll = false
+					continue
+				}
+
+				// Delete the row in commits table
+				err = commits.DeleteRow(cmt.ID)
+				if err != nil {
+					log.Error(err)
+					deletedAll = false
+					continue
+				}
+			}
+
+			// Delete the user row if all rows for the user in the commits tables were deleted
+			if deletedAll {
+				log.Infof("deleting user %s because all of their commits were deleted", u.Username)
+				err = users.DeleteRow(u.ID)
+				if err != nil {
+					log.Error(err)
+				}
+			}
+		}
+
+		// Run the adhoc sorted commits function, this will usually take a while in prod, grab a cup of coffee
+		sorter.RunSortedCommits()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(deleteBotRowsCmd)
+	deleteBotRowsCmd.Flags().StringVar(&startDate, "start-date", "", "The date to start looking for bot data in YYYY-MM-DD format")
+}
+
+func logUsers(users []users.User) {
+	fmt.Println("Deleting user and commit activity for the following users:")
+	for _, u := range users {
+		fmt.Printf(" * %s\n", u.Username)
+	}
+	fmt.Println("Waiting 30 seconds before continuing...")
+}

--- a/internal/db/sorted_commits/sortedCommits.go
+++ b/internal/db/sorted_commits/sortedCommits.go
@@ -41,3 +41,14 @@ func SetNewRecord(c SortedCommit) error {
 	}
 	return nil
 }
+
+// DeleteRow deletes one row in the sorted_commits table by special commit_id (foreign key to commits table)
+// this will only be used to delete bot user activity once detected
+func DeleteRow(id int) error {
+	_, err := db.Exec(`DELETE FROM sorted_commits WHERE commit_id = ?;`, id)
+	if err != nil {
+		return fmt.Errorf("error encountered deleting row for sorted_commits table: %v", err)
+	}
+
+	return nil
+}

--- a/internal/db/users/users_test.go
+++ b/internal/db/users/users_test.go
@@ -1,0 +1,16 @@
+package users
+
+import "testing"
+
+func TestGetBotLikes(t *testing.T) {
+	testBots := []string{
+		"test",
+		"test2",
+		"test3",
+	}
+	expect := `username LIKE '%test%' OR username LIKE '%test2%' OR username LIKE '%test3%'`
+
+	if result := getBotLikes(testBots); result != expect {
+		t.Errorf("Result fail. Received %s, Expected %s", result, expect)
+	}
+}


### PR DESCRIPTION
As we find and identify bot users, this subcommand helps remove bot data that already exists in the database. This will help ensure our data represents normal user activity.