### PR TITLE
Increase ttl on ephemeral aws credentials

### DIFF
--- a/.github/workflows/backups.yaml
+++ b/.github/workflows/backups.yaml
@@ -68,6 +68,7 @@ jobs:
           vault_url: ${{ secrets.VAULT_URL }}
           vault_token: ${{ env.VAULT_TOKEN }}
           role_name: github-repo-backups-s3-upload
+          ttl: 10800s
 
       - name: Run the script
         run: |


### PR DESCRIPTION
The IAM role is already configured with this TTL. Just adding here because I only now realized the default TTL of the role is overruled by the default TTL of the Action. Which is usually sane enough, but this script backs up _a lot_ of repos and needs those credentials for a _hot minute_.