### PR TITLE
Set repository backups as a scheduled workflow only

### DIFF
--- a/.github/workflows/backups.yaml
+++ b/.github/workflows/backups.yaml
@@ -1,9 +1,6 @@
 name: Manage bucket and backup repos
 
 on:
-  push:
-    branches:
-      - "main"
   schedule:
     - cron: '00 0 * * 1'
 


### PR DESCRIPTION
When merging multiple PRs at a time, this workflow running on:push:main is especially annoying. This is fine to only run on the scheduled execution times. 