### PR TITLE
Update makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ all: fmt lint vet build
 
 .PHONY: build
 build: $(BIN) ; $(info $(M) building executable…) @ ## Build program binary
-	$Q CGO_ENABLED=0 $(GO) build \
+	$Q $(GO) build \
 		-tags release \
 		-o $(BIN)/$(notdir $(basename $(MODULE)))$(binext) main.go
 # Tools
@@ -32,64 +32,31 @@ build: $(BIN) ; $(info $(M) building executable…) @ ## Build program binary
 $(BIN):
 	@mkdir -p $@
 $(BIN)/%: | $(BIN) ; $(info $(M) building $(PACKAGE)…)
-	$Q tmp=$$(mktemp -d); \
-	   env GO111MODULE=off GOPATH=$$tmp GOBIN=$(BIN) $(GO) get $(PACKAGE) \
+	$Q env GOBIN=$(BIN) $(GO) install $(PACKAGE) \
 		|| ret=$$?; \
-	   rm -rf $$tmp ; exit $$ret
+	   exit $$ret
 
 GOLINT = $(BIN)/golint
-$(BIN)/golint: PACKAGE=golang.org/x/lint/golint
+$(BIN)/golint: PACKAGE=golang.org/x/lint/golint@latest
 
 STATICCHECK = $(BIN)/staticcheck
-$(BIN)/staticcheck: PACKAGE=honnef.co/go/tools/cmd/staticcheck
+$(BIN)/staticcheck: PACKAGE=honnef.co/go/tools/cmd/staticcheck@latest
 
 ERRCHECK = $(BIN)/errcheck
-$(BIN)/errcheck: PACKAGE=github.com/kisielk/errcheck
-
-GOCOV = $(BIN)/gocov
-$(BIN)/gocov: PACKAGE=github.com/axw/gocov/...
-
-GOCOVXML = $(BIN)/gocov-xml
-$(BIN)/gocov-xml: PACKAGE=github.com/AlekSi/gocov-xml
-
-GO2XUNIT = $(BIN)/go2xunit
-$(BIN)/go2xunit: PACKAGE=github.com/tebeka/go2xunit
+$(BIN)/errcheck: PACKAGE=github.com/kisielk/errcheck@latest
 
 # Tests
 
 TEST_TARGETS := test-default test-bench test-short test-verbose test-race
-.PHONY: $(TEST_TARGETS) test-xml check test tests
+.PHONY: $(TEST_TARGETS) check test tests
 test-bench:   ARGS=-run=__absolutelynothing__ -bench=. ## Run benchmarks
 test-short:   ARGS=-short        ## Run only short tests
-test-verbose: ARGS=-v            ## Run tests in verbose mode with coverage reporting
+test-verbose: ARGS=-v            ## Run tests in verbose mode
 test-race:    ARGS=-race         ## Run tests with race detector
 $(TEST_TARGETS): NAME=$(MAKECMDGOALS:test-%=%)
 $(TEST_TARGETS): test
 check test tests: fmt lint vet staticcheck errcheck; $(info $(M) running $(NAME:%=% )tests…) @ ## Run tests
 	$Q $(GO) test -timeout $(TIMEOUT)s $(ARGS) $(TESTPKGS)
-
-test-xml: fmt lint vet staticcheck errcheck | $(GO2XUNIT) ; $(info $(M) running xUnit tests…) @ ## Run tests with xUnit output
-	$Q mkdir -p test
-	$Q 2>&1 $(GO) test -timeout $(TIMEOUT)s -v $(TESTPKGS) | tee test/tests.output
-	$(GO2XUNIT) -fail -input test/tests.output -output test/tests.xml
-
-COVERAGE_MODE    = atomic
-COVERAGE_PROFILE = $(COVERAGE_DIR)/profile.out
-COVERAGE_XML     = $(COVERAGE_DIR)/coverage.xml
-COVERAGE_HTML    = $(COVERAGE_DIR)/index.html
-.PHONY: test-coverage test-coverage-tools
-test-coverage-tools: | $(GOCOV) $(GOCOVXML)
-test-coverage: COVERAGE_DIR := $(CURDIR)/test/coverage
-test-coverage: fmt lint vet staticcheck errcheck test-coverage-tools ; $(info $(M) running coverage tests…) @ ## Run coverage tests
-	$Q mkdir -p $(COVERAGE_DIR)
-	$Q $(GO) test \
-		-coverpkg=$$($(GO) list -f '{{ join .Deps "\n" }}' $(TESTPKGS) | \
-					grep '^$(MODULE)/' | \
-					tr '\n' ',' | sed 's/,$$//') \
-		-covermode=$(COVERAGE_MODE) \
-		-coverprofile="$(COVERAGE_PROFILE)" $(TESTPKGS)
-	$Q $(GO) tool cover -html=$(COVERAGE_PROFILE) -o $(COVERAGE_HTML)
-	$Q $(GOCOV) convert $(COVERAGE_PROFILE) | $(GOCOVXML) > $(COVERAGE_XML)
 
 .PHONY: lint
 lint: | $(GOLINT) ; $(info $(M) running golint…) @ ## Run golint
@@ -116,7 +83,7 @@ errcheck: | $(ERRCHECK) ; $(info $(M) running errcheck…) @
 .PHONY: clean
 clean: ; $(info $(M) cleaning…)	@ ## Cleanup everything
 	@rm -rf $(BIN)
-	@rm -rf test/tests.* test/coverage.*
+	@rm -rf test/tests.*
 
 .PHONY: help
 help:


### PR DESCRIPTION
Go 1.22 seems to have changed the behavior of `go get`  such that some of our usages of it in our Go project Makefile for pulling in various linters and static analysis tools was broken. This switches to using `go install` to pull those in tester CI job(s).