### PR TITLE
Disable CGO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ all: fmt lint vet build
 
 .PHONY: build
 build: $(BIN) ; $(info $(M) building executable…) @ ## Build program binary
-	$Q $(GO) build \
+	$Q CGO_ENABLED=0 $(GO) build \
 		-tags release \
 		-o $(BIN)/$(notdir $(basename $(MODULE)))$(binext) main.go
 # Tools


### PR DESCRIPTION
CGO needs to be explicitly disabled or the executable fails to load some linked C libraries in some environments.