### PR TITLE
Add fusion-clsp project

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -592,6 +592,7 @@ individual_repositories:
   - https://github.com/trepca/chirp
   - https://github.com/trepca/coinman
   - https://github.com/trgarrett/chialisp
+  - https://github.com/trgarrett/fusion-clsp
   - https://github.com/turekjiri/chia-plot-manager
   - https://github.com/twosson/chia-plotter-CUDA-OpenCl
   - https://github.com/tyc4d/chia-version-update-notification


### PR DESCRIPTION
Add the Fusion Chialisp (fusion-clsp) project providing the reference implementation of the CHIP-0021 NFT fusion.