### PR TITLE
Use distroless runtime image and run as nonroot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM golang:1 as builder
+FROM golang:1 AS builder
 COPY . /app
 WORKDIR /app
 RUN make build
 
-FROM alpine:latest
+FROM gcr.io/distroless/static-debian13:latest
 COPY --from=builder /app/bin/ecosystem-activity /ecosystem-activity
 COPY config.yaml /config.yaml
+USER nonroot:nonroot
 CMD ["/ecosystem-activity"]


### PR DESCRIPTION
## Summary

- Switched the runtime stage from `alpine:latest` to `gcr.io/distroless/static-debian13:latest` for a smaller, more secure base image
- Added `USER nonroot:nonroot` to run the container as a non-root user (the distroless static image ships with a built-in `nonroot` user at uid 65532)
- The binary is already statically linked (`CGO_ENABLED=0` in the Makefile), so `distroless/static` is sufficient — no libc needed
- Reviewed the k8s manifest (`k8s/on-prem.yaml.j2`): no persistent volumes or volume mounts that would conflict with the nonroot user change

Made with [Cursor](https://cursor.com)