### PR TITLE
Add Hadamcik/sage to ecosystem tracking

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -648,6 +648,7 @@ individual_repositories:
   - https://github.com/xch-dev/rue-docs
   - https://github.com/xch-dev/rue-vscode
   - https://github.com/xch-dev/sage
+  - https://github.com/Hadamcik/sage
   - https://github.com/xPatrikTwitch/PatrikPlotter
   - https://github.com/xplicit/chiapos-dotnet
   - https://github.com/xTheJakalx/SimpleChiaMADMAXPlotterGUI


### PR DESCRIPTION
Adds [Hadamcik/sage](https://github.com/Hadamcik/sage) (Sage wallet fork with apps/plugin work) to the ecosystem activity tracker.